### PR TITLE
support multiple arguments

### DIFF
--- a/groundskeeper
+++ b/groundskeeper
@@ -247,7 +247,7 @@ do_default_latest_version() {
 # 1. Get latest release from github
 # 2. If (1) is a pre-release, try fetching the latest non-prerelease from all releases
 # 3. If (1) is invalid/null, try fetching the latest non-prerelease from all releases
-# 
+#
 # ```
 # github_latest_release owner/repo-name
 # ```
@@ -292,7 +292,7 @@ github_last_release() {
   #   - return 0
 
   local last_release=$(echo "${latest_json} | jq -r '[.[] | select(.prerelease == false and .draft == false)][0]'")
-  
+
 }
 
 # Get the github repo ident (owner/repo) from a pkg_source line
@@ -565,7 +565,7 @@ cache_xorg_xcb="$(curl -s https://www.x.org/releases/individual/xcb/)"
 if [ -z $1 ]; then
   get_all_plans
 else
-  ALL_PLANS=("${1}")
+  ALL_PLANS=("$@")
 fi
 
 plan_count_total=0


### PR DESCRIPTION
This makes it a little easier to test a small set of plans.

Before:

```
> ./groundskeeper yasm zlib
[ Habitat ] ------------------------------------------
Fetching origin
HEAD is now at a4894b5 Update CHANGELOG.md with details from pull request #6751

[ Core Plans ] ------------------------------------------
Fetching origin
HEAD is now at 55c0135 Merge pull request #2889 from Defilan/CPM_dotnetsdk_2_2_301

- yasm 1.3.0

[ Summary ] ------------------------------------------
  Total plans:     1
  Found versions:  0
```

After:

```
> ./groundskeeper yasm zlib
[ Habitat ] ------------------------------------------
Fetching origin
HEAD is now at a4894b5 Update CHANGELOG.md with details from pull request #6751

[ Core Plans ] ------------------------------------------
Fetching origin
HEAD is now at 55c0135 Merge pull request #2889 from Defilan/CPM_dotnetsdk_2_2_301

- yasm 1.3.0
- zlib 1.2.11  (base-plan)

[ Summary ] ------------------------------------------
  Total plans:     2
  Found versions:  0
```

Signed-off-by: Steven Danna <steve@chef.io>