### PR TITLE
Fix gtk2 parse error

### DIFF
--- a/groundskeeper
+++ b/groundskeeper
@@ -213,7 +213,14 @@ do_default_latest_version() {
       fi
 
       if [[ "${pkg_source_line}" =~ download\.gnome\.org ]]; then
-        gnome_latest_version "${plan}"
+        case "${plan}" in
+          gtk2)
+            gnome_latest_version_constrained "gtk+" "2\.[2-8]"
+            ;;
+          *)
+            gnome_latest_version "${plan}"
+            ;;
+        esac
         return $?
       fi
 
@@ -394,6 +401,17 @@ gnome_latest_version() {
     | jq -r --arg PLAN_NAME "${plan}" '.[2][$PLAN_NAME] | .[]' \
     | sort --version-sort \
     | tail -1)"
+  return 0
+}
+
+gnome_latest_version_constrained() {
+  local plan="${1}"
+  local constraint="${2}"
+  curl -s "https://download.gnome.org/sources/${plan}/cache.json" \
+    | jq -r --arg PLAN_NAME "${plan}" '.[2][$PLAN_NAME] | .[]' \
+    | sort --version-sort \
+    | grep "^${constraint}" \
+    | tail -1
   return 0
 }
 


### PR DESCRIPTION
On download.gnome.org, the 2.x versions of gtk are in the gtk+
folder. Trying to look for the version information in the non-existent
gtk2 folder resulted in a parse error. Since the 2.x and 3.x versions
are in the same folder, I've constrained this to look at versions that
start with `2.[2-8]`. There is a 2.9x version, but from what I can see
other distributions are not shipping this and from some brief searches
it appears that it might have been the beta versions of gtk 3.

Fixes #4

Signed-off-by: Steven Danna <steve@chef.io>