### PR TITLE
make find invocation compatible with gnu-find

### DIFF
--- a/groundskeeper
+++ b/groundskeeper
@@ -65,7 +65,7 @@ update_repository() {
 
 # Get an array of all plans
 get_all_plans() {
-  ALL_PLANS=($(find "${CLONE_DIR}" -name plan.sh -d 2 | sort | awk -F'/' '{print $2}'))
+  ALL_PLANS=($(find "${CLONE_DIR}" -maxdepth 2 -mindepth 2 -name plan.sh | sort | awk -F'/' '{print $2}'))
 }
 
 debug_plans() {


### PR DESCRIPTION
BSD find support `-depth N` but GNU find does not.

Both seem to support `-mindepth N -maxdepth N` so I've converted it to
that.